### PR TITLE
Add more exported components 

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -112,3 +112,12 @@ export type { VisualFeedbackProps } from './components/VisualFeedback';
 export { default as YesNo } from './components/YesNo';
 export type { YesNoProps } from './components/YesNo';
 export { default as useCounter } from './hooks/useCounter';
+export { default as useBlurEffect } from './hooks/useBlurEffect';
+export { default as useThemeClassName } from './hooks/useThemeClassName';
+export { default as GenericOption } from './components/GenericOption';
+export type { ContentBaseProps, OptionKey } from './components/GenericOption';
+export { default as useKeyboard } from './components/useKeyboard';
+export { default as ThemeContext } from './components/ThemeContext';
+export type { UiMode } from './components/ThemeContext';
+export { default as EmptyOptions } from './components/SelectInputContainer/EmptyOptions';
+


### PR DESCRIPTION
## Changes
    Request to add exports for components and types such as:   
     1. GenericOption and its types (ContentBaseProps & OptionKey)
     2. Hooks: useBlurEffect, useThemeClassName
     3. useKeyboard
     4. EmptyOptions 
     5. ThemeContext, UiMode

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] build works
- [x] eslint issues
- [x] typescript issues
- [x] `console.log` meant for debugging
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] UI changes
